### PR TITLE
Add Gorilla Mux web router

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module atmosian.com
+
+go 1.12
+
+require github.com/gorilla/mux v1.7.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
+github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=

--- a/main.go
+++ b/main.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"github.com/gorilla/mux"
+)
+
+func main() {
+	router := mux.NewRouter()
+
+	// Routes consist of a path and a handler function.
+	router.HandleFunc("/", HelloHandler)
+	
+	// Bind to a port and pass our router in
+	log.Fatal(http.ListenAndServe(":8000", router))
+}
+
+func HelloHandler(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte("Hello Atmosian!\n"))
+}


### PR DESCRIPTION
There is an initial commit.
I suggest choosing this web-router https://github.com/gorilla/mux for dispatching HTTP requests.
Also I added a new module `atmosian.com` (see `go.mod` file)- if this name is not meaningful we can change it.